### PR TITLE
add http headers

### DIFF
--- a/packages/client/nginx.conf
+++ b/packages/client/nginx.conf
@@ -21,12 +21,17 @@ http {
         ssl_certificate_key /etc/ssl/privkey.pem;
 
         ssi on;
-        add_header Strict-Transport-Security "max-age=31536000;";
         ssl_ciphers HIGH:!RC4:!aNULL:!eNULL:!MD5:!EXPORT:!EXP:!LOW:!SEED:!CAMELLIA:!IDEA:!PSK:!SRP:!SSLv2;
         ssl_prefer_server_ciphers on;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
         error_log /var/log/nginx/ssl.error.log;
+
+        add_header X-XSS-Protection          "1; mode=block" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header Referrer-Policy           "no-referrer-when-downgrade" always;
+        add_header Content-Security-Policy   "default-src 'self' http: https: ws: wss: data: blob: 'unsafe-inline'; frame-ancestors 'self';" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         
         location / {
             proxy_set_header Host $host;

--- a/packages/client/src/pages/Leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.tsx
@@ -21,7 +21,7 @@ const columns = [
   },
   {
     field: 'name',
-    headerName: 'Name',
+    headerName: 'Nick',
     width: 150
   },
   {


### PR DESCRIPTION
### Добавить CSP

Добавил http header в nginx.conf

add_header Content-Security-Policy   "default-src 'self' http: https: ws: wss: data: blob: 'unsafe-inline'; frame-ancestors 'self';" always;